### PR TITLE
Add all the rest targets support for sbt-haxe

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ YourHaxeClass.hx:7: Hello, World!
 ```
 
 ## Targets supported
-Currently `sbt-haxe` supports all [targets that haxe supported](http://haxe.org/manual/target-details.html) and all of them are disabled by default except `java`, so if you want to compile to specific target other than `java`,
-you need to enable it manually in `build.sbt`.
+Currently `sbt-haxe` supports all [targets that haxe supported](http://haxe.org/manual/target-details.html) and all of them are disabled by default except `java`, so if you want to compile to specific target other than `java`, you need to enable it manually in `build.sbt`.
 
 - JavaScript `enablePlugins(HaxeJsPlugin)`
 - PHP `enablePlugins(HaxePhpPlugin)`

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Add the following line to your `project/plugins.sbt`:
 
-    addSbtPlugin("com.qifun" % "sbt-haxe" % "1.3.0")
+    addSbtPlugin("com.qifun" % "sbt-haxe" % "1.4.0")
 
 ### Step 2: Put your Haxe sources at `src/haxe/yourPackage/YourHaxeClass.hx`
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ YourHaxeClass.hx:7: Hello, World!
 [success] Total time: 1 s, completed 2014-7-25 10:00:23
 ```
 
+## Targets supported
+Currently `sbt-haxe` supports all [targets that haxe supported](http://haxe.org/manual/target-details.html) and all of them are disabled by default except `java`, so if you want to compile to specific target other than `java`,
+you need to enable it manually in `build.sbt`.
+
+- JavaScript `enablePlugins(HaxeJsPlugin)`
+- PHP `enablePlugins(HaxePhpPlugin)`
+- Neko `enablePlugins(HaxeNekoPlugin)`
+- C# `enablePlugins(HaxeCSharpPlugin)`
+- Python `enablePlugins(HaxePythonPlugin)`
+- C++ `enablePlugins(HaxeCppPlugin)`
+- Flash `enablePlugins(HaxeFlashPlugin)`
+- Action Script 3 `enablePlugins(HaxeAs3Plugin)`
+
 ## Tasks and settings
 
 `sbt-haxe` provides following tasks and settings:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ YourHaxeClass.hx:7: Hello, World!
 ## Targets supported
 Currently `sbt-haxe` supports all [targets that haxe supported](http://haxe.org/manual/target-details.html) and all of them are disabled by default except `java`, so if you want to compile to specific target other than `java`, you need to enable it manually in `build.sbt`.
 
+And here's a [sbt-haxe-sample](https://github.com/new-cbs/sbt-haxe-sample) project to show how to use them.
+
 - JavaScript `enablePlugins(HaxeJsPlugin)`
 - PHP `enablePlugins(HaxePhpPlugin)`
 - Neko `enablePlugins(HaxeNekoPlugin)`

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalacOptions += "-deprecation"
 
 scalacOptions += "-feature"
 
-version := "1.3.1-SNAPSHOT"
+version := "1.4.1-SNAPSHOT"
 
 description := "A Sbt plugin used to compile Haxe sources in Java/Scala projects."
 

--- a/src/main/scala/com/qifun/sbtHaxe/HaxeAs3Plugin.scala
+++ b/src/main/scala/com/qifun/sbtHaxe/HaxeAs3Plugin.scala
@@ -1,0 +1,53 @@
+/*
+ * sbt-haxe
+ * Copyright 2014 深圳岂凡网络有限公司 (Shenzhen QiFun Network Corp., LTD)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.qifun.sbtHaxe
+
+import HaxeConfigurations._
+import HaxeKeys._
+import sbt.Keys._
+import sbt._
+
+/**
+ * A Plugin used to compile Haxe sources to Action Script 3 sources.
+ */
+object HaxeAs3Plugin extends AutoPlugin {
+  override final lazy val projectSettings: Seq[Setting[_]] = {
+    sbt.addArtifact(artifact in packageBin in HaxeAs3, packageBin in HaxeAs3) ++
+      inConfig(As3)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(TestAs3)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(HaxeAs3)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(HaxeAs3)(SbtHaxe.extendSettings) ++
+      inConfig(TestHaxeAs3)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(TestHaxeAs3)(SbtHaxe.extendTestSettings) ++
+      SbtHaxe.injectSettings(HaxeAs3, As3) ++
+      SbtHaxe.injectSettings(TestHaxeAs3, TestAs3) ++
+      Seq(
+        haxeXmls in Compile ++= (haxeXml in As3).value,
+        haxeXmls in Test ++= (haxeXml in TestAs3).value,
+        haxePlatformName in As3 := "as3",
+        haxePlatformName in TestAs3 := "as3",
+        haxeOutputPath in As3 := Some((target in haxe in As3).value),
+        haxeOutputPath in TestAs3 := Some((target in haxe in As3).value),
+        doxRegex in Compile := SbtHaxe.buildDoxRegex((sourceDirectories in HaxeAs3).value),
+        doxRegex in Test := SbtHaxe.buildDoxRegex((sourceDirectories in TestHaxeAs3).value),
+        ivyConfigurations += Haxe,
+        ivyConfigurations += TestHaxe,
+        ivyConfigurations += HaxeAs3,
+        ivyConfigurations += TestHaxeAs3)
+  }
+}

--- a/src/main/scala/com/qifun/sbtHaxe/HaxeCSharpPlugin.scala
+++ b/src/main/scala/com/qifun/sbtHaxe/HaxeCSharpPlugin.scala
@@ -26,9 +26,6 @@ import HaxeConfigurations._
  * A plugin used to compile Haxe sources to CSharp sources.
  */
 final object HaxeCSharpPlugin extends AutoPlugin {
-  override final def requires = BaseHaxePlugin
-  override final def trigger = allRequirements
-
   override final lazy val projectSettings: Seq[Setting[_]] =
     sbt.addArtifact(artifact in packageBin in HaxeCSharp, packageBin in HaxeCSharp) ++
       inConfig(CSharp)(SbtHaxe.baseHaxeSettings) ++

--- a/src/main/scala/com/qifun/sbtHaxe/HaxeConfigurations.scala
+++ b/src/main/scala/com/qifun/sbtHaxe/HaxeConfigurations.scala
@@ -56,6 +56,12 @@ trait HaxeConfigurations {
 
   final lazy val HaxePython = config("haxe-python") extend Haxe
   final lazy val TestHaxePython = config("test-haxe-python") extend HaxePython
+
+  final lazy val Neko = config("neko")
+  final lazy val TestNeko = config("test-neko")
+
+  final lazy val HaxeNeko = config("haxe-neko") extend Haxe
+  final lazy val TestHaxeNeko = config("test-haxe-neko") extend HaxeNeko
 }
 
 final object HaxeConfigurations extends HaxeConfigurations

--- a/src/main/scala/com/qifun/sbtHaxe/HaxeConfigurations.scala
+++ b/src/main/scala/com/qifun/sbtHaxe/HaxeConfigurations.scala
@@ -58,10 +58,16 @@ trait HaxeConfigurations {
   final lazy val TestHaxePython = config("test-haxe-python") extend HaxePython
 
   final lazy val Neko = config("neko")
-  final lazy val TestNeko = config("test-neko")
+  final lazy val TestNeko = config("test-neko") extend Neko
 
   final lazy val HaxeNeko = config("haxe-neko") extend Haxe
   final lazy val TestHaxeNeko = config("test-haxe-neko") extend HaxeNeko
+
+  final lazy val Flash = config("flash")
+  final lazy val TestFlash = config("test-flash") extend Flash
+
+  final lazy val HaxeFlash = config("haxe-flash")
+  final lazy val TestHaxeFlash = config("test-haxe-flash") extend HaxeFlash
 }
 
 final object HaxeConfigurations extends HaxeConfigurations

--- a/src/main/scala/com/qifun/sbtHaxe/HaxeConfigurations.scala
+++ b/src/main/scala/com/qifun/sbtHaxe/HaxeConfigurations.scala
@@ -33,6 +33,12 @@ trait HaxeConfigurations {
   final lazy val HaxeCSharp = config("haxe-csharp") extend Haxe
   final lazy val TestHaxeCSharp = config("test-haxe-csharp") extend HaxeCSharp
 
+  final lazy val Cpp = config("cpp")
+  final lazy val TestCpp = config("test-cpp") extend Cpp
+
+  final lazy val HaxeCpp = config("haxe-cpp") extend Haxe
+  final lazy val TestHaxeCpp = config("test-haxe-cpp") extend HaxeCpp
+
   final lazy val Js = config("js")
   final lazy val TestJs = config("test-js") extend Js
 

--- a/src/main/scala/com/qifun/sbtHaxe/HaxeConfigurations.scala
+++ b/src/main/scala/com/qifun/sbtHaxe/HaxeConfigurations.scala
@@ -44,6 +44,12 @@ trait HaxeConfigurations {
 
   final lazy val HaxePhp = config("haxe-php") extend Haxe
   final lazy val TestHaxePhp = config("test-haxe-php") extend HaxePhp
+
+  final lazy val Python = config("python")
+  final lazy val TestPython = config("test-python") extend Python
+
+  final lazy val HaxePython = config("haxe-python") extend Haxe
+  final lazy val TestHaxePython = config("test-haxe-python") extend HaxePython
 }
 
 final object HaxeConfigurations extends HaxeConfigurations

--- a/src/main/scala/com/qifun/sbtHaxe/HaxeConfigurations.scala
+++ b/src/main/scala/com/qifun/sbtHaxe/HaxeConfigurations.scala
@@ -66,8 +66,14 @@ trait HaxeConfigurations {
   final lazy val Flash = config("flash")
   final lazy val TestFlash = config("test-flash") extend Flash
 
-  final lazy val HaxeFlash = config("haxe-flash")
+  final lazy val HaxeFlash = config("haxe-flash") extend Haxe
   final lazy val TestHaxeFlash = config("test-haxe-flash") extend HaxeFlash
+
+  final lazy val As3 = config("as3")
+  final lazy val TestAs3 = config("test-as3") extend As3
+
+  final lazy val HaxeAs3 = config("haxe-as3") extend Haxe
+  final lazy val TestHaxeAs3 = config("test-haxe-as3") extend HaxeAs3
 }
 
 final object HaxeConfigurations extends HaxeConfigurations

--- a/src/main/scala/com/qifun/sbtHaxe/HaxeConfigurations.scala
+++ b/src/main/scala/com/qifun/sbtHaxe/HaxeConfigurations.scala
@@ -38,6 +38,12 @@ trait HaxeConfigurations {
 
   final lazy val HaxeJs = config("haxe-js") extend Haxe
   final lazy val TestHaxeJs = config("test-haxe-js") extend HaxeJs
+
+  final lazy val Php = config("php")
+  final lazy val TestPhp = config("test-php") extend Php
+
+  final lazy val HaxePhp = config("haxe-php") extend Haxe
+  final lazy val TestHaxePhp = config("test-haxe-php") extend HaxePhp
 }
 
 final object HaxeConfigurations extends HaxeConfigurations

--- a/src/main/scala/com/qifun/sbtHaxe/HaxeCppPlugin.scala
+++ b/src/main/scala/com/qifun/sbtHaxe/HaxeCppPlugin.scala
@@ -1,0 +1,38 @@
+package com.qifun.sbtHaxe
+
+import HaxeConfigurations._
+import HaxeKeys._
+import sbt.Keys._
+import sbt._
+
+/**
+ * A Plugin used to compile Haxe sources to C++ sources.
+ */
+object HaxeCppPlugin extends AutoPlugin {
+  override final def trigger = allRequirements
+
+  override final lazy val projectSettings: Seq[Setting[_]] = {
+    sbt.addArtifact(artifact in packageBin in HaxeCpp, packageBin in HaxeCpp) ++
+      inConfig(Cpp)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(TestCpp)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(HaxeCpp)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(HaxeCpp)(SbtHaxe.extendSettings) ++
+      inConfig(TestHaxeCpp)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(TestHaxeCpp)(SbtHaxe.extendTestSettings) ++
+      SbtHaxe.injectSettings(HaxeCpp, Cpp) ++
+      SbtHaxe.injectSettings(TestHaxeCpp, TestCpp) ++
+      Seq(
+        haxeXmls in Compile ++= (haxeXml in Cpp).value,
+        haxeXmls in Test ++= (haxeXml in TestCpp).value,
+        haxePlatformName in Cpp := "cpp",
+        haxePlatformName in TestCpp := "cpp",
+        haxeOutputPath in Cpp := Some((target in haxe in Cpp).value),
+        haxeOutputPath in TestCpp := Some((target in haxe in Cpp).value),
+        doxRegex in Compile := SbtHaxe.buildDoxRegex((sourceDirectories in HaxeCpp).value),
+        doxRegex in Test := SbtHaxe.buildDoxRegex((sourceDirectories in TestHaxeCpp).value),
+        ivyConfigurations += Haxe,
+        ivyConfigurations += TestHaxe,
+        ivyConfigurations += HaxeCpp,
+        ivyConfigurations += TestHaxeCpp)
+  }
+}

--- a/src/main/scala/com/qifun/sbtHaxe/HaxeCppPlugin.scala
+++ b/src/main/scala/com/qifun/sbtHaxe/HaxeCppPlugin.scala
@@ -1,3 +1,20 @@
+/*
+ * sbt-haxe
+ * Copyright 2014 深圳岂凡网络有限公司 (Shenzhen QiFun Network Corp., LTD)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.qifun.sbtHaxe
 
 import HaxeConfigurations._
@@ -9,8 +26,6 @@ import sbt._
  * A Plugin used to compile Haxe sources to C++ sources.
  */
 object HaxeCppPlugin extends AutoPlugin {
-  override final def trigger = allRequirements
-
   override final lazy val projectSettings: Seq[Setting[_]] = {
     sbt.addArtifact(artifact in packageBin in HaxeCpp, packageBin in HaxeCpp) ++
       inConfig(Cpp)(SbtHaxe.baseHaxeSettings) ++

--- a/src/main/scala/com/qifun/sbtHaxe/HaxeFlashPlugin.scala
+++ b/src/main/scala/com/qifun/sbtHaxe/HaxeFlashPlugin.scala
@@ -1,0 +1,54 @@
+/*
+ * sbt-haxe
+ * Copyright 2014 深圳岂凡网络有限公司 (Shenzhen QiFun Network Corp., LTD)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.qifun.sbtHaxe
+
+import HaxeConfigurations._
+import HaxeKeys._
+import sbt.Keys._
+import sbt._
+
+/**
+ * A Plugin used to compile Haxe sources to Flash swf file.
+ */
+object HaxeFlashPlugin extends AutoPlugin {
+  override final lazy val projectSettings: Seq[Setting[_]] = {
+    sbt.addArtifact(artifact in packageBin in HaxeFlash, packageBin in HaxeFlash) ++
+      inConfig(Flash)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(TestFlash)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(HaxeFlash)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(HaxeFlash)(SbtHaxe.extendSettings) ++
+      inConfig(TestHaxeFlash)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(TestHaxeFlash)(SbtHaxe.extendTestSettings) ++
+      SbtHaxe.injectSettings(HaxeFlash, Flash) ++
+      SbtHaxe.injectSettings(TestHaxeFlash, TestFlash) ++
+      Seq(
+        haxeXmls in Compile ++= (haxeXml in Flash).value,
+        haxeXmls in Test ++= (haxeXml in TestFlash).value,
+        haxePlatformName in Flash := "swf",
+        haxePlatformName in TestFlash := "swf",
+        haxeOutputPath in Flash := Some(file((target in haxe in Flash).value.getPath + ".swf")),
+        haxeOutputPath in TestFlash := Some(file((target in haxe in Flash).value.getPath + ".swf")),
+        doxRegex in Compile := SbtHaxe.buildDoxRegex((sourceDirectories in HaxeFlash).value),
+        doxRegex in Test := SbtHaxe.buildDoxRegex((sourceDirectories in TestHaxeFlash).value),
+        ivyConfigurations += Haxe,
+        ivyConfigurations += TestHaxe,
+        ivyConfigurations += HaxeFlash,
+        ivyConfigurations += TestHaxeFlash)
+  }
+
+}

--- a/src/main/scala/com/qifun/sbtHaxe/HaxeJsPlugin.scala
+++ b/src/main/scala/com/qifun/sbtHaxe/HaxeJsPlugin.scala
@@ -1,3 +1,20 @@
+/*
+ * sbt-haxe
+ * Copyright 2014 深圳岂凡网络有限公司 (Shenzhen QiFun Network Corp., LTD)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.qifun.sbtHaxe
 
 import HaxeConfigurations._
@@ -9,8 +26,6 @@ import sbt._
  * A Plugin used to compile Haxe sources to JavaScript sources.
  */
 object HaxeJsPlugin extends AutoPlugin {
-  override final def trigger = allRequirements
-
   override final lazy val projectSettings: Seq[Setting[_]] = {
     sbt.addArtifact(artifact in packageBin in HaxeJs, packageBin in HaxeJs) ++
       inConfig(Js)(SbtHaxe.baseHaxeSettings) ++

--- a/src/main/scala/com/qifun/sbtHaxe/HaxeNekoPlugin.scala
+++ b/src/main/scala/com/qifun/sbtHaxe/HaxeNekoPlugin.scala
@@ -1,0 +1,38 @@
+package com.qifun.sbtHaxe
+
+import HaxeConfigurations._
+import HaxeKeys._
+import sbt.Keys._
+import sbt._
+
+/**
+ * A Plugin used to compile Haxe sources to Neko binary.
+ */
+object HaxeNekoPlugin extends AutoPlugin {
+  override final def trigger = allRequirements
+
+  override final lazy val projectSettings: Seq[Setting[_]] = {
+    sbt.addArtifact(artifact in packageBin in HaxeNeko, packageBin in HaxeNeko) ++
+      inConfig(Neko)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(TestNeko)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(HaxeNeko)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(HaxeNeko)(SbtHaxe.extendSettings) ++
+      inConfig(TestHaxeNeko)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(TestHaxeNeko)(SbtHaxe.extendTestSettings) ++
+      SbtHaxe.injectSettings(HaxeNeko, Neko) ++
+      SbtHaxe.injectSettings(TestHaxeNeko, TestNeko) ++
+      Seq(
+        haxeXmls in Compile ++= (haxeXml in Neko).value,
+        haxeXmls in Test ++= (haxeXml in TestNeko).value,
+        haxePlatformName in Neko := "neko",
+        haxePlatformName in TestNeko := "neko",
+        haxeOutputPath in Neko := Some(file((target in haxe in Neko).value.getPath + ".n")),
+        haxeOutputPath in TestNeko := Some(file((target in haxe in Neko).value.getPath + ".n")),
+        doxRegex in Compile := SbtHaxe.buildDoxRegex((sourceDirectories in HaxeNeko).value),
+        doxRegex in Test := SbtHaxe.buildDoxRegex((sourceDirectories in TestHaxeNeko).value),
+        ivyConfigurations += Haxe,
+        ivyConfigurations += TestHaxe,
+        ivyConfigurations += HaxeNeko,
+        ivyConfigurations += TestHaxeNeko)
+  }
+}

--- a/src/main/scala/com/qifun/sbtHaxe/HaxeNekoPlugin.scala
+++ b/src/main/scala/com/qifun/sbtHaxe/HaxeNekoPlugin.scala
@@ -1,3 +1,20 @@
+/*
+ * sbt-haxe
+ * Copyright 2014 深圳岂凡网络有限公司 (Shenzhen QiFun Network Corp., LTD)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.qifun.sbtHaxe
 
 import HaxeConfigurations._
@@ -9,8 +26,6 @@ import sbt._
  * A Plugin used to compile Haxe sources to Neko binary.
  */
 object HaxeNekoPlugin extends AutoPlugin {
-  override final def trigger = allRequirements
-
   override final lazy val projectSettings: Seq[Setting[_]] = {
     sbt.addArtifact(artifact in packageBin in HaxeNeko, packageBin in HaxeNeko) ++
       inConfig(Neko)(SbtHaxe.baseHaxeSettings) ++

--- a/src/main/scala/com/qifun/sbtHaxe/HaxePhpPlugin.scala
+++ b/src/main/scala/com/qifun/sbtHaxe/HaxePhpPlugin.scala
@@ -1,3 +1,20 @@
+/*
+ * sbt-haxe
+ * Copyright 2014 深圳岂凡网络有限公司 (Shenzhen QiFun Network Corp., LTD)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.qifun.sbtHaxe
 
 import HaxeConfigurations._
@@ -9,8 +26,6 @@ import sbt._
  * A Plugin used to compile Haxe sources to PHP sources.
  */
 object HaxePhpPlugin extends AutoPlugin {
-  override final def trigger = allRequirements
-
   override final lazy val projectSettings: Seq[Setting[_]] = {
     sbt.addArtifact(artifact in packageBin in HaxePhp, packageBin in HaxePhp) ++
       inConfig(Php)(SbtHaxe.baseHaxeSettings) ++

--- a/src/main/scala/com/qifun/sbtHaxe/HaxePhpPlugin.scala
+++ b/src/main/scala/com/qifun/sbtHaxe/HaxePhpPlugin.scala
@@ -1,0 +1,38 @@
+package com.qifun.sbtHaxe
+
+import HaxeConfigurations._
+import HaxeKeys._
+import sbt.Keys._
+import sbt._
+
+/**
+ * A Plugin used to compile Haxe sources to PHP sources.
+ */
+object HaxePhpPlugin extends AutoPlugin {
+  override final def trigger = allRequirements
+
+  override final lazy val projectSettings: Seq[Setting[_]] = {
+    sbt.addArtifact(artifact in packageBin in HaxePhp, packageBin in HaxePhp) ++
+      inConfig(Php)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(TestPhp)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(HaxePhp)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(HaxePhp)(SbtHaxe.extendSettings) ++
+      inConfig(TestHaxePhp)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(TestHaxePhp)(SbtHaxe.extendTestSettings) ++
+      SbtHaxe.injectSettings(HaxePhp, Php) ++
+      SbtHaxe.injectSettings(TestHaxePhp, TestPhp) ++
+      Seq(
+        haxeXmls in Compile ++= (haxeXml in Php).value,
+        haxeXmls in Test ++= (haxeXml in TestPhp).value,
+        haxePlatformName in Php := "php",
+        haxePlatformName in TestPhp := "php",
+        haxeOutputPath in Php := Some((target in haxe in Php).value),
+        haxeOutputPath in TestPhp := Some((target in haxe in Php).value),
+        doxRegex in Compile := SbtHaxe.buildDoxRegex((sourceDirectories in HaxePhp).value),
+        doxRegex in Test := SbtHaxe.buildDoxRegex((sourceDirectories in TestHaxePhp).value),
+        ivyConfigurations += Haxe,
+        ivyConfigurations += TestHaxe,
+        ivyConfigurations += HaxePhp,
+        ivyConfigurations += TestHaxePhp)
+  }
+}

--- a/src/main/scala/com/qifun/sbtHaxe/HaxePythonPlugin.scala
+++ b/src/main/scala/com/qifun/sbtHaxe/HaxePythonPlugin.scala
@@ -1,0 +1,38 @@
+package com.qifun.sbtHaxe
+
+import HaxeConfigurations._
+import HaxeKeys._
+import sbt.Keys._
+import sbt._
+
+/**
+ * A Plugin used to compile Haxe sources to Python sources.
+ */
+object HaxePythonPlugin extends AutoPlugin {
+  override final def trigger = allRequirements
+
+  override final lazy val projectSettings: Seq[Setting[_]] = {
+    sbt.addArtifact(artifact in packageBin in HaxePython, packageBin in HaxePython) ++
+      inConfig(Python)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(TestPython)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(HaxePython)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(HaxePython)(SbtHaxe.extendSettings) ++
+      inConfig(TestHaxePython)(SbtHaxe.baseHaxeSettings) ++
+      inConfig(TestHaxePython)(SbtHaxe.extendTestSettings) ++
+      SbtHaxe.injectSettings(HaxePython, Python) ++
+      SbtHaxe.injectSettings(TestHaxePython, TestPython) ++
+      Seq(
+        haxeXmls in Compile ++= (haxeXml in Python).value,
+        haxeXmls in Test ++= (haxeXml in TestPython).value,
+        haxePlatformName in Python := "python",
+        haxePlatformName in TestPython := "python",
+        haxeOutputPath in Python := Some(file((target in haxe in Python).value.getPath + ".py")),
+        haxeOutputPath in TestPython := Some(file((target in haxe in Python).value.getPath + ".py")),
+        doxRegex in Compile := SbtHaxe.buildDoxRegex((sourceDirectories in HaxePython).value),
+        doxRegex in Test := SbtHaxe.buildDoxRegex((sourceDirectories in TestHaxePython).value),
+        ivyConfigurations += Haxe,
+        ivyConfigurations += TestHaxe,
+        ivyConfigurations += HaxePython,
+        ivyConfigurations += TestHaxePython)
+  }
+}

--- a/src/main/scala/com/qifun/sbtHaxe/HaxePythonPlugin.scala
+++ b/src/main/scala/com/qifun/sbtHaxe/HaxePythonPlugin.scala
@@ -1,3 +1,20 @@
+/*
+ * sbt-haxe
+ * Copyright 2014 深圳岂凡网络有限公司 (Shenzhen QiFun Network Corp., LTD)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.qifun.sbtHaxe
 
 import HaxeConfigurations._
@@ -9,8 +26,6 @@ import sbt._
  * A Plugin used to compile Haxe sources to Python sources.
  */
 object HaxePythonPlugin extends AutoPlugin {
-  override final def trigger = allRequirements
-
   override final lazy val projectSettings: Seq[Setting[_]] = {
     sbt.addArtifact(artifact in packageBin in HaxePython, packageBin in HaxePython) ++
       inConfig(Python)(SbtHaxe.baseHaxeSettings) ++


### PR DESCRIPTION
This is part of the implementation for #56 

Targets:
- php
- python
- c++
- neko
- flash
- action script 3

and https://github.com/new-cbs/sbt-haxe-sample is a project to verify it with samples